### PR TITLE
Fix: Deploy to Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node app.js 

--- a/app.js
+++ b/app.js
@@ -26,6 +26,6 @@ let app = express();
 
 
 
-let listener = app.listen(8001, () => {
+let listener = app.listen((process.env.PORT || 8001), () => {
 	console.log(`[MastodonRater] I'm running on port:${listener.address().port}✨`);
 });


### PR DESCRIPTION
Herokuへのデプロイに関して手を加えておきました。

以下、変更点

- Node.jsでのデプロイ時のportを環境変数から取得
- composer.jsonをリネームし、Procfileへ変更

Herokuではポートを環境変数から取得するようになっているようです。
その為、8001ポートではアプリケーションエラーとなっていました。

それと、composer.jsonが存在しているために、PHPのアプリケーションだとHeroku側で認識されていました。
それも修正してあります。